### PR TITLE
Ignore test code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
       uses: actions-rs/tarpaulin@v0.1
       with:
         version: latest
+        args: --ignore-tests
 
     - name: Upload code coverage
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
Code coverage appears to be including tests. This configures tarpaulin to ignore test lines.