### PR TITLE
Use informational code coverage mode

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,11 @@
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        informational: true
+
 ignore:
 - "**/tests"
 - "**/benches"


### PR DESCRIPTION
This sets code coverage for the project to informational mode while under active development. It should allow for significant decreases in coverage without marking as failure.