### PR TITLE
Preserve map key order

### DIFF
--- a/crates/brace-config/Cargo.toml
+++ b/crates/brace-config/Cargo.toml
@@ -13,7 +13,8 @@ json = ["serde_json"]
 yaml = ["serde_yaml"]
 
 [dependencies]
+indexmap = { version = "1.3", features = ["serde-1"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
+serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 serde_yaml = { version = "0.8", optional = true }
-toml = { version = "0.5", optional = true }
+toml = { version = "0.5", features = ["preserve_order"], optional = true }

--- a/crates/brace-config/src/value/mod.rs
+++ b/crates/brace-config/src/value/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use indexmap::IndexMap;
 use serde::de::{
     Deserialize, DeserializeOwned, Deserializer, IntoDeserializer, MapAccess, SeqAccess, Visitor,
 };
@@ -252,7 +253,7 @@ impl<'de> Deserialize<'de> for Value {
             where
                 V: MapAccess<'de>,
             {
-                let mut map = HashMap::new();
+                let mut map = IndexMap::new();
 
                 while let Some(key) = visitor.next_key()? {
                     map.insert(key, visitor.next_value()?);
@@ -396,6 +397,12 @@ impl From<Vec<Value>> for Value {
 
 impl From<HashMap<String, Value>> for Value {
     fn from(value: HashMap<String, Value>) -> Self {
+        Value::Table(Table::from(value))
+    }
+}
+
+impl From<IndexMap<String, Value>> for Value {
+    fn from(value: IndexMap<String, Value>) -> Self {
         Value::Table(Table::from(value))
     }
 }

--- a/crates/brace-config/src/value/ser.rs
+++ b/crates/brace-config/src/value/ser.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt::{self, Display};
 
+use indexmap::IndexMap;
 use serde::ser::{
     Error as SerError, Impossible, Serialize, SerializeMap, SerializeSeq, SerializeStruct,
     SerializeStructVariant, SerializeTuple, SerializeTupleStruct, SerializeTupleVariant,
@@ -136,7 +136,7 @@ impl Serializer for ValueSerializer {
     where
         T: ?Sized + Serialize,
     {
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
 
         map.insert(String::from(variant), value.serialize(self)?);
 
@@ -176,7 +176,7 @@ impl Serializer for ValueSerializer {
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Error> {
         Ok(TableMapSerializer {
-            map: HashMap::new(),
+            map: IndexMap::new(),
             next_key: None,
         })
     }
@@ -198,7 +198,7 @@ impl Serializer for ValueSerializer {
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Ok(TableMapMatrixSerializer {
             name: String::from(variant),
-            map: HashMap::new(),
+            map: IndexMap::new(),
         })
     }
 }
@@ -280,7 +280,7 @@ impl SerializeTupleVariant for ArraySeqMatrixSerializer {
     }
 
     fn end(self) -> Result<Value, Error> {
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
 
         map.insert(self.name, Value::from(self.seq));
 
@@ -289,7 +289,7 @@ impl SerializeTupleVariant for ArraySeqMatrixSerializer {
 }
 
 pub struct TableMapSerializer {
-    pub(crate) map: HashMap<String, Value>,
+    pub(crate) map: IndexMap<String, Value>,
     pub(crate) next_key: Option<String>,
 }
 
@@ -344,7 +344,7 @@ impl SerializeStruct for TableMapSerializer {
 
 pub struct TableMapMatrixSerializer {
     pub(crate) name: String,
-    pub(crate) map: HashMap<String, Value>,
+    pub(crate) map: IndexMap<String, Value>,
 }
 
 impl SerializeStructVariant for TableMapMatrixSerializer {
@@ -362,7 +362,7 @@ impl SerializeStructVariant for TableMapMatrixSerializer {
     }
 
     fn end(self) -> Result<Value, Error> {
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
 
         map.insert(self.name, Value::from(self.map));
 

--- a/crates/brace-config/src/value/table.rs
+++ b/crates/brace-config/src/value/table.rs
@@ -1,13 +1,14 @@
-use std::collections::hash_map::{HashMap, IntoIter, Iter, IterMut};
+use std::collections::HashMap;
 use std::fmt;
 
+use indexmap::map::{IndexMap, IntoIter, Iter, IterMut};
 use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, Serializer};
 
 use super::{de::ValueDeserializer, ser::ValueSerializer, Error, Key, Value};
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Table(HashMap<String, Value>);
+pub struct Table(IndexMap<String, Value>);
 
 impl Table {
     pub fn new() -> Self {
@@ -64,7 +65,7 @@ impl Table {
 
 impl Default for Table {
     fn default() -> Self {
-        Self(HashMap::new())
+        Self(IndexMap::new())
     }
 }
 
@@ -108,7 +109,7 @@ impl<'de> Deserialize<'de> for Table {
             where
                 V: MapAccess<'de>,
             {
-                let mut map = HashMap::new();
+                let mut map = IndexMap::new();
 
                 while let Some(key) = visitor.next_key()? {
                     map.insert(key, visitor.next_value()?);
@@ -150,8 +151,20 @@ impl<'a> IntoIterator for &'a mut Table {
 }
 
 impl From<HashMap<String, Value>> for Table {
-    fn from(map: HashMap<String, Value>) -> Self {
+    fn from(from: HashMap<String, Value>) -> Self {
+        let mut map = IndexMap::new();
+
+        for (key, val) in from {
+            map.insert(key, val);
+        }
+
         Self(map)
+    }
+}
+
+impl From<IndexMap<String, Value>> for Table {
+    fn from(from: IndexMap<String, Value>) -> Self {
+        Self(from)
     }
 }
 


### PR DESCRIPTION
This switches the project to using the `indexmap` crate in order to preserve the map key order.