### PR TITLE
Update linting and code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - master
+
 jobs:
   lint:
     name: Lint
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -27,7 +29,7 @@ jobs:
         args: --all -- --check
 
     - name: Clippy
-      uses: actions-rs/clippy-check@v1
+      uses: brace-rs/clippy-check@b75a09651cc90c3921c41888815fe6a7a0b0adae
       with:
         args: --all -- -D warnings
         name: Lint / Results
@@ -36,7 +38,6 @@ jobs:
   build:
     name: Build / ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    needs: lint
     strategy:
       matrix:
         target:
@@ -102,7 +103,6 @@ jobs:
   test:
     name: Test / ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    needs: lint
     strategy:
       matrix:
         target:
@@ -168,7 +168,6 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    needs: lint
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,9 @@ coverage:
     project:
       default:
         informational: true
+    patch:
+      default:
+        informational: true
 
 ignore:
 - "**/tests"

--- a/crates/brace-config/src/config.rs
+++ b/crates/brace-config/src/config.rs
@@ -113,8 +113,8 @@ mod tests {
     fn test_float() {
         let mut cfg = Config::new();
 
-        assert!(cfg.set("f32", 32 as f32).is_ok());
-        assert!(cfg.set("f64", 64 as f64).is_ok());
+        assert!(cfg.set::<_, f32>("f32", 32.0).is_ok());
+        assert!(cfg.set::<_, f64>("f64", 64.0).is_ok());
 
         assert_eq!(cfg.get::<_, f32>("f32"), Ok(32.0 as f32));
         assert_eq!(cfg.get::<_, f64>("f64"), Ok(64.0 as f64));
@@ -305,8 +305,8 @@ mod tests {
             cfg.get::<_, Complex>("e"),
             Ok(Complex::E {
                 a: String::from("a"),
-                b: map.clone(),
-                c: arr.clone(),
+                b: map,
+                c: arr,
             })
         );
 


### PR DESCRIPTION
This updates the project to follow the latest changes to the continuous integration workflow and local IDE setup to the standard found across other projects. In particular these relate to linting changes and code coverage.